### PR TITLE
Generate example makefiles on Cori

### DIFF
--- a/cori/config-bout-cgpu-nohypre.csh
+++ b/cori/config-bout-cgpu-nohypre.csh
@@ -86,7 +86,6 @@ if ( "$pkg" == "BOUT-dev" ) then
           -DBUILD_SHARED_LIBS=Off \
           -DBOUT_TESTS=On \
           -DCHECK=1 \
-          -DBOUT_BUILD_EXAMPLES=OFF \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
           -DCMAKE_VERBOSE_MAKEFILE=On \
           -Dgtest_disable_pthreads=On \

--- a/cori/config-bout-cgpu-nohypre.sh
+++ b/cori/config-bout-cgpu-nohypre.sh
@@ -84,7 +84,6 @@ if [ "$pkg" == "BOUT-dev" ]; then
           -DBUILD_SHARED_LIBS=Off \
           -DBOUT_TESTS=On \
           -DCHECK=1 \
-          -DBOUT_BUILD_EXAMPLES=OFF \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
           -DCMAKE_VERBOSE_MAKEFILE=On \
           -Dgtest_disable_pthreads=On \

--- a/cori/config-bout-cgpu.csh
+++ b/cori/config-bout-cgpu.csh
@@ -86,7 +86,6 @@ if ( "$pkg" == "BOUT-dev" ) then
           -DBUILD_SHARED_LIBS=Off \
           -DBOUT_TESTS=On \
           -DCHECK=1 \
-          -DBOUT_BUILD_EXAMPLES=OFF \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
           -DCMAKE_VERBOSE_MAKEFILE=On \
           -Dgtest_disable_pthreads=On \

--- a/cori/config-bout-cgpu.sh
+++ b/cori/config-bout-cgpu.sh
@@ -79,7 +79,6 @@ if [ "$pkg" == "BOUT-dev" ]; then
           -DBUILD_SHARED_LIBS=Off \
           -DBOUT_TESTS=On \
           -DCHECK=1 \
-          -DBOUT_BUILD_EXAMPLES=OFF \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
           -DCMAKE_VERBOSE_MAKEFILE=On \
           -Dgtest_disable_pthreads=On \


### PR DESCRIPTION
Previously BOUT_BUILD_EXAMPLES was set to `OFF` because it would actually build all the examples. Now this flag just generates the makefiles, and adds a new target to build all examples.