### PR TITLE
Marconi: Replace module openmpi/4.1.1--gnu--8.3.0 with openmpi/3.1.4--gnu--7.3.0

### DIFF
--- a/marconi-gnu-openmpi/bout.env
+++ b/marconi-gnu-openmpi/bout.env
@@ -2,4 +2,4 @@
 #
 # Enable by doing `source bout.env` in your terminal, or source (using the full path) in your .bashrc
 
-module load env-skl profile/advanced intel/pe-xe-2020--binary gnu/8.3.0 openmpi/4.1.1--gnu--8.3.0 mkl/2020--binary cmake
+module load env-skl profile/advanced intel/pe-xe-2020--binary gnu/7.3.0 openmpi/3.1.4--gnu--7.3.0 mkl/2020--binary cmake


### PR DESCRIPTION
The openmpi/4.1.1--gnu--8.3.0 module seems not to work on more than one node. Therefore downgrade gcc to 7.3.0 and use openmpi/3.1.4--gnu--7.3.0 instead.