### PR TITLE
Revert "Fixed bug due to old version of CMake on Marconi"

### DIFF
--- a/marconi-gnu-openmpi/build.sh
+++ b/marconi-gnu-openmpi/build.sh
@@ -9,6 +9,6 @@ cd ../BOUT-dev
 
 git submodule update --init --recursive
 
-cmake . -B build-gnu-openmpi -DCMAKE_BUILD_TYPE=Release -DCHECK=0 -DBOUT_DOWNLOAD_SUNDIALS=ON -DBOUT_USE_PETSC=ON -DPETSC_DIR=$DEPS_PATH/petsc-build -DPETSC_ARCH="" -DBOUT_USE_HDF5=OFF -DNC_CONFIG=$DEPS_PATH/netcdf-build/bin/nc-config -DNCXX4_CONFIG=$DEPS_PATH/netcdf-build/bin/ncxx4-config -DFFTW_ROOT=$DEPS_PATH/fftw-build -DBOUT_IGNORE_CONDA_ENV=ON -DBOUT_UPDATE_GIT_SUBMODULE=OFF -DBOUT_BUILD_EXAMPLES=ON
+cmake . -B build-gnu-openmpi -DCMAKE_BUILD_TYPE=Release -DCHECK=0 -DBOUT_DOWNLOAD_SUNDIALS=ON -DBOUT_USE_PETSC=ON -DPETSC_DIR=$DEPS_PATH/petsc-build -DPETSC_ARCH="" -DBOUT_USE_HDF5=OFF -DNC_CONFIG=$DEPS_PATH/netcdf-build/bin/nc-config -DNCXX4_CONFIG=$DEPS_PATH/netcdf-build/bin/ncxx4-config -DFFTW_ROOT=$DEPS_PATH/fftw-build -DBOUT_IGNORE_CONDA_ENV=ON
 
 cmake --build build-gnu-openmpi -j 16


### PR DESCRIPTION
This reverts commit a5b82a276e2c5db54671ba28ec1195ae26ed0998.

https://github.com/boutproject/BOUT-configs/pull/6#issuecomment-1196963091:
> Actually, we don't want to make this change...:
>* The CMake issue has been fixed in BOUT++ on the `master` branch, and will be fixed on `next` when `master` is merged. The `marconi` branch of `BOUT-configs` is intended to build the latest release version, which at the moment is 4.4.2 and includes the fix so no workaround is needed here. The workaround disables automatic running of `git submodule update ...` by CMake, which is normally a good thing to have.
>* Also I don't think we want to set `-DBOUT_BUILD_EXAMPLES=ON` by default. On `master` I think it always builds all the examples (which is a waste of time and disk space when they are not needed), and on `next` I think it is on by default anyway (which makes sense as on `next` the examples are only configured and not built). If `BOUT_BUILD_EXAMPLES=ON` is not working by default on `next`, that's a bug somewhere in BOUT++'s CMake config and needs an issue on `BOUT-dev`.
