### PR TITLE
Add note on CMake finding BLAS for PhysicsModels

### DIFF
--- a/archer/README.md
+++ b/archer/README.md
@@ -51,6 +51,9 @@ Quick start
       signal test fails.
 6. To build your `PhysicsModel`, see the instructions at
    https://bout-dev.readthedocs.io/en/latest/user_docs/installing.html#using-cmake-with-your-physics-model
+   Note: you will likely need to use the flag `-DCMAKE_CXX_COMPILER=CC` when 
+   compiling your application with CMake. This can help CMake find BLAS
+   correctly in ARCHER2's Cray environment.
 
 
 Notes


### PR DESCRIPTION
Added a hint to the readme based on an issue I had in compiling Hermes-3 where CMake gave me the following message:
```
CMake Error at /mnt/lustre/a2fs-work1/work/y07/shared/utils/core/cmake/3.21.3/share/cmake-3.21/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find BLAS (missing: BLAS_LIBRARIES)
Call Stack (most recent call first):
  /mnt/lustre/a2fs-work1/work/y07/shared/utils/core/cmake/3.21.3/share/cmake-3.21/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
  /mnt/lustre/a2fs-work1/work/y07/shared/utils/core/cmake/3.21.3/share/cmake-3.21/Modules/FindBLAS.cmake:1162 (find_package_handle_standard_args)
  /mnt/lustre/a2fs-work1/work/y07/shared/utils/core/cmake/3.21.3/share/cmake-3.21/Modules/FindLAPACK.cmake:227 (find_package)
  /mnt/lustre/a2fs-work1/work/y07/shared/utils/core/cmake/3.21.3/share/cmake-3.21/Modules/FindLAPACK.cmake:252 (_lapack_find_dependency)
  /mnt/lustre/a2fs-work1/work/y07/shared/utils/core/cmake/3.21.3/share/cmake-3.21/Modules/CMakeFindDependencyMacro.cmake:47 (find_package)
  /work/e281/e281/mkryjak/BOUT-7152948/BOUT-dev/build/bout++Config.cmake:151 (find_dependency)
  CMakeLists.txt:48 (find_package)
```

This was the case even though BOUT++ and PETSc compiled fine without issues. BOUT++ did show a `Found BLAS: 1` during compilation as well.

It turns out Cray systems have BLAS implicitly linked which makes CMake need a different than usual routine for finding BLAS. This is from FindBLAS.cmake:
```
# On compilers that implicitly link BLAS (i.e. CrayPrgEnv) we used a
# placeholder for empty BLAS_LIBRARIES to get through our logic above.
if(BLAS_LIBRARIES STREQUAL "BLAS_LIBRARIES-PLACEHOLDER-FOR-EMPTY-LIBRARIES")
  set(BLAS_LIBRARIES "")
endif()
```

This is further explained here: https://gitlab.kitware.com/cmake/cmake/-/merge_requests/2312

It turns out that you need to tell CMake explicitly what compiler you use and this resolves the issue. I think from this it is able to figure out it is in a Cray environment and activate the above workaround (this is a guess). You can achieve this by ensuring you use the CMake flag `-DCMAKE_CXX_COMPILER=CC` in Hermes-3 (and presumably in other applications too) just like in the BOUT++ CMake command.




