### PR TITLE
Fix submodule urls for generic-next; bump BOUT++ commit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "archer/BOUT-dev"]
 	path = generic-next/BOUT-dev
-	url = git@github.com:boutproject/BOUT-dev
+	url = https://github.com/boutproject/BOUT-dev.git

--- a/generic-next/README.md
+++ b/generic-next/README.md
@@ -13,7 +13,7 @@ Quick start
     ```
 2. Clone this repo/branch
     ```
-    git clone git@github.com:boutproject/BOUT-configs -b generic-next
+    git clone https://github.com/boutproject/BOUT-configs.git -b generic-next
     ```
 3. `cd BOUT-configs/generic-next`
 4. Build the dependencies


### PR DESCRIPTION
Submodule urls used git protocol so are less beginner-friendly