### PR TITLE
Add hypre in spack environment and cmake script

### DIFF
--- a/perlmutter/boutdev-spack-env/spack.yaml
+++ b/perlmutter/boutdev-spack-env/spack.yaml
@@ -11,7 +11,8 @@ spack:
   - umpire@2022.03.1+cuda~examples+numa+openmp cuda_arch=80
   - fmt@10.0.0
   - netcdf-cxx4@4.3.1
-  - fftw@3.3.10
+  - fftw@3.3.10~mpi
+  - hypre+cuda+umpire~mpi~superlu-dist cuda_arch=80
   view: true
   concretizer:
     unify: true

--- a/perlmutter/scripts/cmake-hypre.sh
+++ b/perlmutter/scripts/cmake-hypre.sh
@@ -1,0 +1,15 @@
+rm -rf build-hypre
+cmake -S BOUT-dev -B build-hypre \
+    -DCMAKE_C_COMPILER=gcc \
+    -DCMAKE_CXX_COMPILER=g++ \
+    -DBUILD_SHARED_LIBS=off \
+    -DBOUT_ENABLE_RAJA=on \
+    -DBOUT_ENABLE_UMPIRE=on \
+    -DBOUT_ENABLE_CUDA=on \
+    -DBOUT_USE_HYPRE=on \
+    -DCMAKE_CUDA_ARCHITECTURES=80 \
+    -DCUDA_ARCH=compute_80,code=sm_80 \
+    -DBOUT_ENABLE_WARNINGS=off \
+    -DBOUT_USE_SYSTEM_FMT=on
+
+# HYPRE_ROOT


### PR DESCRIPTION
The PR adds support for hypre with CUDA and an associated cmake script to build BOUT++ with hypre enabled.