### PR TITLE
Fix MPI building on perlmutter

### DIFF
--- a/perlmutter/boutdev-spack-env/spack.yaml
+++ b/perlmutter/boutdev-spack-env/spack.yaml
@@ -5,15 +5,15 @@
 spack:
   # add package specs to the `specs` list
   include:
+  - /global/common/software/spackecp/perlmutter/spack_settings/compilers.yaml
   - /global/common/software/spackecp/perlmutter/spack_settings/packages.yaml
   specs:
-  - cmake@3.24.3
   - raja@git.v2023.06.1+cuda~examples~exercises+openmp cuda_arch=80
   - umpire@2022.03.1~shared+cuda~examples+numa+openmp cuda_arch=80
   - fmt@10.0.0
   - netcdf-cxx4@4.3.1
   - fftw@3.3.10~mpi
-  - hypre-cmake@git.v2.31.0~shared+cuda+umpire~mpi~superlu-dist cuda_arch=80
+  - hypre-cmake@git.v2.31.0~shared+cuda+umpire+mpi~superlu-dist cuda_arch=80
   view: true
   concretizer:
     unify: true
@@ -22,16 +22,18 @@ spack:
   packages:
     all:
       compiler: [gcc@12.3.0]
-    gmake:
-      externals:
-      - spec: gmake@4.2.1
-        prefix: /usr
-      buildable: false
+      providers:
+        mpi: [cray-mpich]
     cmake:
       externals:
       - spec: cmake@3.24.3
         modules:
         - cmake/3.24.3
+      buildable: false
+    gmake:
+      externals:
+      - spec: gmake@4.2.1
+        prefix: /usr
       buildable: false
     gcc:
       externals:
@@ -48,17 +50,3 @@ spack:
     cub:
       require:
         - "@2.0.1"
-  compilers:
-  - compiler:
-      spec: gcc@=12.3.0
-      paths:
-        cc: /usr/bin/gcc
-        cxx: /usr/bin/g++
-        f77: /usr/bin/gfortran
-        fc: /usr/bin/gfortran
-      flags: {}
-      operating_system: sles15
-      target: x86_64
-      modules: []
-      environment: {}
-      extra_rpaths: []

--- a/perlmutter/setup-env.sh
+++ b/perlmutter/setup-env.sh
@@ -1,11 +1,22 @@
-echo "Setting up spack env on $(hostname)"
-# Disable MPICH GPU to avoid runtime error
-# TODO: fix
-export MPICH_GPU_SUPPORT_ENABLED=0
+echo "Setting up BOUT++ spack env on $(hostname)..."
+module purge 2> /dev/null
+. /opt/cray/pe/cpe/23.12/restore_lmod_system_defaults.sh
+module load PrgEnv-gnu
+module load cmake/3.24.3
+module load gcc-native/12.3
+module load craype-x86-milan
+module load libfabric
+module load cudatoolkit/12.2
+
+# Set the path to the parent directory.
+BOUT_CONFIG_PATH=$(dirname "${BASH_SOURCE[0]:-$0}")
+echo "BOUT_CONFIG_PATH = ${BOUT_CONFIG_PATH}"
 
 # Import spack and setup packages
-export SPACK_USER_CONFIG_PATH=${PWD}/.spack
-export SPACK_USER_CACHE_PATH=${PWD}/.spack
-. ${PWD}/../spack/share/spack/setup-env.sh
-spack env activate -p boutdev-spack-env
-echo $(spack install --fail-fast)
+export SPACK_USER_CONFIG_PATH=${BOUT_CONFIG_PATH}/.spack
+export SPACK_USER_CACHE_PATH=${BOUT_CONFIG_PATH}/.spack
+. ${BOUT_CONFIG_PATH}/../spack/share/spack/setup-env.sh
+spack env activate -p ${BOUT_CONFIG_PATH}/boutdev-spack-env
+set -x
+spack install --fail-fast
+set +x


### PR DESCRIPTION
This commit fixes building HYPRE and BOUT++ with MPI enabled on perlmutter, using the cray-mpich version. Also, it simplifies sourcing the environment script, which now can be sourced anywhere in the path and not only within the BOUT-configs root.